### PR TITLE
Fix auto-calculation parameter order issue

### DIFF
--- a/js/crypto.js
+++ b/js/crypto.js
@@ -65,11 +65,9 @@ document.addEventListener('DOMContentLoaded', () => {
     
     // Set up auto-calculation for buy form
     setupAutoCalculation('buy-crypto-quantity', 'buy-crypto-price', 'buy-crypto-total');
-    setupAutoCalculation('buy-crypto-quantity', 'buy-crypto-total', 'buy-crypto-price');
     
     // Set up auto-calculation for sell form
     setupAutoCalculation('sell-crypto-quantity', 'sell-crypto-price', 'sell-crypto-total');
-    setupAutoCalculation('sell-crypto-quantity', 'sell-crypto-total', 'sell-crypto-price');
     
     // Price updates are now handled automatically from the dashboard
     

--- a/js/etfs.js
+++ b/js/etfs.js
@@ -63,11 +63,9 @@ document.addEventListener('DOMContentLoaded', () => {
     
     // Set up auto-calculation for buy form
     setupAutoCalculation('buy-etf-quantity', 'buy-etf-price', 'buy-etf-total');
-    setupAutoCalculation('buy-etf-quantity', 'buy-etf-total', 'buy-etf-price');
     
     // Set up auto-calculation for sell form
     setupAutoCalculation('sell-etf-quantity', 'sell-etf-price', 'sell-etf-total');
-    setupAutoCalculation('sell-etf-quantity', 'sell-etf-total', 'sell-etf-price');
     
     // Price updates are now handled automatically from the dashboard
     

--- a/js/stocks.js
+++ b/js/stocks.js
@@ -65,11 +65,9 @@ document.addEventListener('DOMContentLoaded', () => {
     
     // Set up auto-calculation for buy form
     setupAutoCalculation('buy-stock-quantity', 'buy-stock-price', 'buy-stock-total');
-    setupAutoCalculation('buy-stock-quantity', 'buy-stock-total', 'buy-stock-price');
     
     // Set up auto-calculation for sell form
     setupAutoCalculation('sell-stock-quantity', 'sell-stock-price', 'sell-stock-total');
-    setupAutoCalculation('sell-stock-quantity', 'sell-stock-total', 'sell-stock-price');
     
     // Price updates are now handled automatically from the dashboard
     


### PR DESCRIPTION
- Remove duplicate setupAutoCalculation calls with wrong parameter order
- The second call was swapping price and total parameters, causing reverse calculations
- Now correctly: Quantity × Price = Total, Total ÷ Quantity = Price
- Fixes issue where 10 × 10 was showing as 1 instead of 100
- Fixes issue where 10 ÷ 10 was showing as 100 instead of 1
- Applied fix to stocks.js, etfs.js, and crypto.js