### PR TITLE
Fix dashboard error: remove call to non-existent updateDashboardReali…

### DIFF
--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -29,9 +29,6 @@ document.addEventListener('DOMContentLoaded', () => {
     loadExchangeRate();
     updateExchangeRateLabel();
     
-    // Update realized P&L display
-    updateDashboardRealizedPnL();
-    
     // Start scheduled updates
     startScheduledUpdates();
     


### PR DESCRIPTION
…zedPnL function

- Remove call to updateDashboardRealizedPnL() in dashboard.js DOMContentLoaded event
- Function was removed earlier but call was left behind causing ReferenceError
- Realized P&L is now calculated as part of updateDashboardStats() function