### PR TITLE
Add automatic price fetching for sold assets

### DIFF
--- a/js/crypto.js
+++ b/js/crypto.js
@@ -353,6 +353,10 @@ async function updateCryptoPrices() {
     
     await Promise.all(promises);
     savePriceCache();
+    
+    // Also update sold assets prices
+    await fetchSoldAssetsPrices();
+    
     renderCrypto();
     
     if (getCryptoPricesBtn) {

--- a/js/crypto.js
+++ b/js/crypto.js
@@ -354,8 +354,8 @@ async function updateCryptoPrices() {
     await Promise.all(promises);
     savePriceCache();
     
-    // Also update sold assets prices
-    await fetchSoldAssetsPrices();
+    // Also update sold assets prices (crypto only)
+    await fetchSoldAssetsPrices('crypto');
     
     renderCrypto();
     

--- a/js/etfs.js
+++ b/js/etfs.js
@@ -335,8 +335,8 @@ async function updateEtfPrices() {
     await Promise.all(promises);
     savePriceCache();
     
-    // Also update sold assets prices
-    await fetchSoldAssetsPrices();
+    // Also update sold assets prices (ETFs only)
+    await fetchSoldAssetsPrices('etfs');
     
     renderEtfs();
     

--- a/js/etfs.js
+++ b/js/etfs.js
@@ -334,6 +334,10 @@ async function updateEtfPrices() {
     
     await Promise.all(promises);
     savePriceCache();
+    
+    // Also update sold assets prices
+    await fetchSoldAssetsPrices();
+    
     renderEtfs();
     
     if (getEtfsPricesBtn) {

--- a/js/stocks.js
+++ b/js/stocks.js
@@ -398,8 +398,8 @@ async function updateStockPrices() {
     await Promise.all(promises);
     savePriceCache();
     
-    // Also update sold assets prices
-    await fetchSoldAssetsPrices();
+    // Also update sold assets prices (stocks only)
+    await fetchSoldAssetsPrices('stocks');
     
     renderStocks();
     

--- a/js/stocks.js
+++ b/js/stocks.js
@@ -397,6 +397,10 @@ async function updateStockPrices() {
     
     await Promise.all(promises);
     savePriceCache();
+    
+    // Also update sold assets prices
+    await fetchSoldAssetsPrices();
+    
     renderStocks();
     
     if (getStocksPricesBtn) {


### PR DESCRIPTION
- Enhance getCurrentPriceForSoldAsset() to check both main priceCache and soldAssetsCache
- Add fetchSoldAssetsPrices() function to automatically fetch prices for all sold assets
- Integrate sold assets price fetching into global and individual asset price updates
- Update stocks, ETFs, and crypto price update functions to include sold assets
- Ensure sold assets always have current prices for accurate 'If Held' P&L analysis
- Fix issue where sold assets showed stale or missing current prices

This resolves the problem where assets that were completely sold would no longer have their current prices updated, making the sold assets analysis inaccurate.